### PR TITLE
https://github.com/loginFix issue where C code does not execute after forking

### DIFF
--- a/src/code-template/[id]/update-code-template.ts
+++ b/src/code-template/[id]/update-code-template.ts
@@ -7,6 +7,7 @@ import {
     MAX_CHARS_TITLE_DESCRIPTION,
     MIN_CHARS,
     MAX_CHARS_TAG,
+    LANGUAGES,
 } from "../../../constants";
 import { createOrUpdateTags } from "@/src/utils";
 import { withAuth } from "@/src/auth/middleware";
@@ -27,7 +28,7 @@ const updateCodeTemplateSchema = Joi.object({
     title: Joi.string().min(MIN_CHARS).max(MAX_CHARS_TITLE_DESCRIPTION),
     description: Joi.string().min(MIN_CHARS).max(MAX_CHARS_TITLE_DESCRIPTION),
     code: Joi.string().max(MAX_CHARS_CONTENT),
-    language: Joi.string().min(2).max(50), 
+    language: Joi.string().valid(...LANGUAGES).optional(),
     tags: Joi.array().items(Joi.string().min(MIN_CHARS).max(MAX_CHARS_TAG)),
 });
 


### PR DESCRIPTION
The update code template validation had a minimum length requirement of 2 characters for the language field, which conflicted with the 'C' language option. Changed the validation to use the same allowed languages list as the create template endpoint.

**Summary**

Add a short description of the PR

**Review Notes**

Include any comments for the reviewers of this PR. For example, something you want reviewed closely.
Delete this section if not needed.

**Testing**

Add a detailed description of the testing performed. Include screenshots or videos if needed.

- Test 1: ...


- Test 2: ...

Issues to be closed by this PR: 
- https://github.com/Scriptorium-CSC309/web/issues/sample-issue
